### PR TITLE
Add command line option --deadtime to affect one_measurement function

### DIFF
--- a/README
+++ b/README
@@ -2,9 +2,15 @@
 ------------------------------
 
 To build and install PowerTOP type the following commands, 
-	./configure 
-	./make
-	./make install
+	autoconf --install
+	mkdir build
+	cd build
+	../configure
+	make
+	
+	or simply run
+	
+	./autogen.sh
 
 Note: For Android (running Intel Architecture ) there is a Android.mk 
 that was provided by community members, and at this time is supported

--- a/README
+++ b/README
@@ -7,10 +7,12 @@ To build and install PowerTOP type the following commands,
 	cd build
 	../configure
 	make
+	make install
 	
 	or simply run
 	
 	./autogen.sh
+	make install
 
 Note: For Android (running Intel Architecture ) there is a Android.mk 
 that was provided by community members, and at this time is supported

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,3 +1,7 @@
 #!/bin/sh	
 
 autoreconf --install --verbose
+mkdir build
+cd build
+../configure
+make

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -410,14 +410,11 @@ int main(int argc, char **argv)
 #endif
 	ui_notify_user = ui_notify_user_ncurses;
 	while (1) { /* parse commandline options */
-		c = getopt_long(argc, argv, "cC:r:i:qt:w:Vh", long_options, &option_index);
+		c = getopt_long(argc, argv, "cC:d:r:i:qt:w:Vh", long_options, &option_index);
 		/* Detect the end of the options. */
 		if (c == -1)
 			break;
 		switch (c) {
-		case 'd':
-			dead_time = (optarg ? atoi(optarg) : 0);
-			break;
 		case OPT_AUTO_TUNE:
 			auto_tune = 1;
 			leave_powertop = 1;
@@ -429,6 +426,9 @@ int main(int argc, char **argv)
 		case 'C':		/* csv report */
 			reporttype = REPORT_CSV;
 			sprintf(filename, "%s", optarg ? optarg : "powertop.csv");
+			break;
+		case 'd':
+			dead_time = (optarg ? atoi(optarg) : 0);
 			break;
 		case OPT_DEBUG:
 			/* implemented using getopt_long(3) flag */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -398,7 +398,7 @@ int main(int argc, char **argv)
 	char filename[4096];
 	char workload[4096] = {0,};
 	int  iterations = 1, auto_tune = 0;
-	int  calibrate = 0;
+	int  calibration = 0;
 
 	set_new_handler(out_of_memory);
 
@@ -424,7 +424,7 @@ int main(int argc, char **argv)
 			ui_notify_user = ui_notify_user_console;
 			break;
 		case 'c':
-			calibrate = 1;
+			calibration = 1;
 			break;
 		case 'C':		/* csv report */
 			reporttype = REPORT_CSV;
@@ -471,7 +471,7 @@ int main(int argc, char **argv)
 
 	powertop_init();
 	
-	if (calibrate)
+	if (calibration)
 		calibrate();
 
 	if (reporttype != REPORT_OFF)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,7 +85,7 @@ static const struct option long_options[] =
 	{"calibrate",	no_argument,		NULL,		 'c'},
 	{"csv",		optional_argument,	NULL,		 'C'},
 	{"debug",	no_argument,		&debug_learning, OPT_DEBUG},
-	{"deadtime"	optional_argument,	NULL,		 'd'},
+	{"deadtime",	optional_argument,	NULL,		 'd'},
 	{"extech",	optional_argument,	NULL,		 OPT_EXTECH},
 	{"html",	optional_argument,	NULL,		 'r'},
 	{"iteration",	optional_argument,	NULL,		 'i'},


### PR DESCRIPTION
One 15 second measurement does not measure previous data if the data only updates every 30 seconds. This commit gives the option to increase this value on systems which have slow update times for calibration purposes. It adds a before and during measurement time of 'dead_time' to the function one_measurement via a global variable.

When one_measurement is called, this change causes an effective delay before starting measurements so that the system changes recently made will be measured. It also adds time to the measurement process. This has no effect when a workload is run as this would require changing the workload itself. The main anticipated use of this function is to improve calibration.

*Add command line parameter option of dead time.
*Added global variable unsigned int dead_time:
This is similar to the time out option which is not used during calibration but has a similar purpose (not sure of exactly how it is used) - (perhaps merge the two later)

*Added code to main to retrieve the command line option
*Added code to one_measurement to add a before and during measurement delay of dead_time in seconds.
*Added anticipated bug fix where calibration was being called before all command line parameters are parsed.

If this has unintended consequences the global variable can be passed to the calibration function. However since it may have utility outside of this function I have left it in for testing purposes.
